### PR TITLE
Fix gray background color in slotted div

### DIFF
--- a/src/styles/elements/c-navigation.scss
+++ b/src/styles/elements/c-navigation.scss
@@ -94,7 +94,6 @@
 ::slotted(div) {
   border-top: 1px solid #e2e2e2;
   padding: 10px 25px;
-  background: #f5f5f5;
   
   // IE
   a {
@@ -133,7 +132,6 @@ ul {
       &.toggle-sub {
         border-top: 0;
         position: relative;
-        background-color: #f5f5f5;
       }
     }
     .caption {


### PR DESCRIPTION
- Removed background color for navbar toggler and slotted div so it matched with navigation background

**Solving issue**</br>
Fixes: #61 

How to test:
Go to c-navigation example, resize to mobile view and check navigation.
Check background color in dropdown More and in "Back" on subnavigation.

