### PR TITLE
Active colors for links and social-media added in c-footer

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -249,7 +249,7 @@ $extra-colors: (
 
 $element-colors: (
   'headings-color': $headings-color,
-  'link-color': var(--info),
+  'link-color': $link-color,
   'link-color-hover': $link-color-hover,
   'link-color-active': $link-color-active,
   'link-color-disabled': $link-color-disabled

--- a/src/styles/components/_navs.scss
+++ b/src/styles/components/_navs.scss
@@ -3,7 +3,7 @@
 .nav-link {
   //IE
   text-decoration: none;
-  
+
   --link-color:#{$link-color};
   --link-decoration: none;
   font-size: 1.4rem;
@@ -26,5 +26,14 @@
     color: $link-color-disabled;
     --link-color: #{$link-color-disabled};
     font-weight: normal;
+  }
+}
+
+// TODO: Refine this primary color setup
+.nav-pills {
+
+  .nav-link.active,
+  .show > .nav-link {
+    @include component('primary');
   }
 }

--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -4,15 +4,12 @@
   color: $light-01; // IE
   padding: 5px;
   text-align: center;
+  text-decoration: none;
 
   &:hover {
-    color: $light-01; // IE
     text-decoration: underline;
   }
 
-  &.active { // IE
-    text-decoration: underline;
-  }
 }
 
 @mixin nav-link-social {
@@ -34,17 +31,13 @@
     background-color: $light-01;
   }
 
-  &.active {
-    color: #000;
-    background-color: #fff;
-  }
-
 }
 
 :host {
   --link-color: var(--light-01);
   --link-color-hover: var(--light-01);
   --link-decoration: none;
+  text-decoration: none;
   --link-decoration-hover: underline;
   --link-color-active: var(--light-01);
   background-color: #000;
@@ -57,6 +50,22 @@
   @include nav-link-social;
 }
 
+// IE support links
+::slotted(a:active),
+::slotted(a.active),
+::slotted(a[active]:not([active="false"])) {
+  color: white;
+  text-decoration: underline;
+}
+
+// IE support social items
+::slotted(a[slot="social-items"]:active),
+::slotted(a[slot="social-items"].active),
+::slotted(a[slot="social-items"][active]:not([active="false"])) {
+  color:black;
+  background-color: white;
+}
+
 a {
   color: $light-01; // IE
 
@@ -64,6 +73,7 @@ a {
     color: $light-01; // IE
   }
 }
+// Copyright text
 p {
   font-size: 1.4rem;
   color: #fff;
@@ -153,6 +163,7 @@ p {
     @extend %nav-link-social-desktop;
   }
 
+  // Copyright text
   p {
     text-align: left;
     padding: 0;

--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -9,6 +9,10 @@
     color: $light-01; // IE
     text-decoration: underline;
   }
+
+  &.active { // IE
+    text-decoration: underline;
+  }
 }
 
 @mixin nav-link-social {
@@ -29,6 +33,12 @@
     color: #000;
     background-color: $light-01;
   }
+
+  &.active {
+    color: #000;
+    background-color: #fff;
+  }
+
 }
 
 :host {
@@ -36,7 +46,7 @@
   --link-color-hover: var(--light-01);
   --link-decoration: none;
   --link-decoration-hover: underline;
-
+  --link-color-active: var(--light-01);
   background-color: #000;
 }
 
@@ -84,8 +94,9 @@ p {
   }
 }
 .social-items {
-  --link-color-hover: black;
-  --link-bg-hover: white;
+  --link-color-hover: #000;
+  --link-bg-hover: #fff;
+  --link-color-active: #000;
 
   padding-left: 20px;
 
@@ -136,7 +147,7 @@ p {
   ::slotted(a) {
     @extend %nav-link-desktop;
   }
-  // Due to browsers not supporting: ::slotted(a):hover 
+  // Due to browsers not supporting: ::slotted(a):hover
   // we need to have the hover separated instead of nested
   ::slotted(a[slot="social-items"]) {
     @extend %nav-link-social-desktop;
@@ -155,7 +166,7 @@ p {
 
     .navbar-nav {
       margin-top: 0px;
-  
+
       .nav-item {
 
         &.nav-link {
@@ -168,7 +179,7 @@ p {
     margin-bottom: 20px;
     padding-left: 0;
     text-align: left;
-    
+
     a.social-item {
       @extend %nav-link-social-desktop;
     }

--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -6,6 +6,7 @@
   text-align: center;
   text-decoration: none;
 
+  // IE underline
   &:hover {
     text-decoration: underline;
   }
@@ -37,7 +38,6 @@
   --link-color: var(--light-01);
   --link-color-hover: var(--light-01);
   --link-decoration: none;
-  text-decoration: none;
   --link-decoration-hover: underline;
   --link-color-active: var(--light-01);
   background-color: #000;
@@ -50,7 +50,7 @@
   @include nav-link-social;
 }
 
-// IE support links
+// Active state for links
 ::slotted(a:active),
 ::slotted(a.active),
 ::slotted(a[active]:not([active="false"])) {
@@ -58,7 +58,7 @@
   text-decoration: underline;
 }
 
-// IE support social items
+// Active for social items
 ::slotted(a[slot="social-items"]:active),
 ::slotted(a[slot="social-items"].active),
 ::slotted(a[slot="social-items"][active]:not([active="false"])) {
@@ -66,13 +66,6 @@
   background-color: white;
 }
 
-a {
-  color: $light-01; // IE
-
-  &:hover {
-    color: $light-01; // IE
-  }
-}
 // Copyright text
 p {
   font-size: 1.4rem;

--- a/src/styles/elements/c-global-style.scss
+++ b/src/styles/elements/c-global-style.scss
@@ -25,15 +25,6 @@
 @import '../utilities/loading.scss';
 @import '../utilities/typography.scss';
 
-// TODO: Refine this primary color setup
-.nav-pills {
-
-  .nav-link.active,
-  .show > .nav-link {
-    @include component('primary');
-  }
-}
-
 $components: badge, list-group-item;
 $componentsLight: alert, table;
 


### PR DESCRIPTION
**Describe pull-request**</br>
There was no styling for active state for c-footer, this adds the correct colors
- IE and Chrome tested

**Solving issue**</br>
Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)
Fixes: scania/corporate-ui-dev#209

Chrome:
![image](https://user-images.githubusercontent.com/35451568/66651637-ce4ab300-ec33-11e9-8fc4-7f5f09cf2f07.png)

