### PR TITLE
Fix sticky navigation z-index

### DIFF
--- a/src/styles/elements/c-navigation.scss
+++ b/src/styles/elements/c-navigation.scss
@@ -30,6 +30,7 @@
   font-weight: bold;
   text-transform: uppercase;
   background-color: #fff;
+  z-index: 2000;
 }
 :host([slot=sub]) {
   background-color: #fff;


### PR DESCRIPTION
- Sticky navigation needs to be on top of other elements

**Describe pull-request**</br>
- Change z-index of c-navigation to 2000


**Solving issue**</br>
Fixes: https://github.com/scania/corporate-ui-dev/issues/220
