### PR TITLE
Fixed css for buttons rendered twice

### DIFF
--- a/src/styles/components/_button-group.scss
+++ b/src/styles/components/_button-group.scss
@@ -1,5 +1,3 @@
-@import 'button';
-
 .btn-group {
 
   &-lg {

--- a/src/styles/components/_dropdowns.scss
+++ b/src/styles/components/_dropdowns.scss
@@ -1,6 +1,5 @@
 @import '../variables';
 @import '../mixins';
-@import 'button';
 
 .dropdown-menu{
   padding: .8rem 1rem;


### PR DESCRIPTION
- @extend in sass will work without the need to import
- Avoid duplication for button css

**Solving issue**</br>
Fixes: #44 

