### PR TITLE
Bug - Fixed root data url for CDN

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -283,7 +283,7 @@ async function initTheme(cb) {
       name = name.substr(0, name.length - 3);
     }
 
-    theme[themeName]['components'][type][name] = data.replace(/url\(../g, 'url(%root%' + root);
+    theme[themeName]['components'][type][name] = data.replace(/url\(\.\./g, 'url(%root%' + root);
     themeNoRefs[themeName]['components'][type][name] = refToData(data);
   });
 

--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -138,6 +138,8 @@ p {
     text-decoration: none;
     padding: 0;
     margin-right: 15px;
+    // TODO : Check stencil generating wrong css variable colors
+    background: inherit;
   }
   // Sass compiler renders :hover and :before differently
   // and this is due to browsers lackof support

--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -7,6 +7,7 @@
   text-align: center;
   text-transform: capitalize;
   font-weight: bold;
+  background: transparent;
 
   &:hover {
     text-decoration: underline;
@@ -64,6 +65,7 @@
 
   .navbar-brand {
     padding: 13px;
+    background-color: transparent;
 
     &:before {
       display: block;


### PR DESCRIPTION
- without escape character, it will replace url for SVG background, changed the regex to only replace resource URL

**How to test**  
- chechkout to this PR branch
- Run npm start in scania-theme
- in local project or codepen, points to http://localhost:1338/scania-theme.js
