### PR TITLE
Bug- Dropdown split button padding changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scania-theme",
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/styles/components/_dropdowns.scss
+++ b/src/styles/components/_dropdowns.scss
@@ -27,6 +27,21 @@
   }
 }
 
+.dropdown-toggle-split {
+  padding-right: 0.5625rem;
+  padding-left: 0.5625rem;
+
+ .btn-lg + & {
+    padding-right: 0.75rem;
+    padding-left: 0.75rem;
+ }
+
+ .btn-sm + & {
+    padding-right: 0.375rem;
+    padding-left: 0.375rem;
+  }
+}
+
 // Override the .show for buttons
 .show {
   @each $type in $interaction-types {


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_

- Fixed missmatching padding for default, lg and sm
- Setup for making it easier to change the styling for padding in the future.

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #84 

**How to test**  
_Add description how to test if possible_

1. Checkout this branch
2. Go to localhost or something using dropdown with button split
3. Look at the padding of the dropdown-toggle-split


