### PR TITLE
Fix bug in footer: on IE it adds white block

### DIFF
--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -82,6 +82,7 @@ p {
 
 .navbar {
   padding: 0;
+  display: inherit;
 
   .navbar-nav {
     text-transform: uppercase;


### PR DESCRIPTION
- Override styling from bootstrap to make it work in IE
- Display flex is not working in IE so we need to inherit from parent which uses display block

Fixes #100 