### PR TITLE
Fix table row size and table head background color

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -128,8 +128,8 @@ $modal-border-color:          $light-03;
 
 // Table
 $table-border-color:          $border-color;
-$table-thead-border-color:    $primary;
-$table-thead-bg-color:        $primary;
+$table-thead-border-color:    $blue;
+$table-thead-bg-color:        $blue;
 
 //Pagination
 $pagination-bg-color:         transparent;

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -31,5 +31,13 @@
   td {
     background-color: inherit;
     box-shadow: inherit;
+    padding: 1.2rem 1.2rem 1.3rem;
+  }
+
+  &.table-sm {
+    th,
+    td {
+      padding: .4rem .5rem .5rem;
+    }
   }
 }


### PR DESCRIPTION
- Added padding to fit height requirement
- Table normal height 50px
- Table small height 34px
- Changed table header background color to scania blue

**Solving issue**  
Fixes: #124 

**How to test**  
- go to corporate-ui-site
- navigate to components > Table
- Check row height and table header bg color value as mentioned in #124 

**Screenshots**  

![image](https://user-images.githubusercontent.com/1199101/79319080-27a7dd80-7f08-11ea-9efa-2c5ee6a1e2cc.png)


**Additional context**  
_Add any other context about the pull-request here._
