### PR TITLE
Solved bug with button active showing above navigation z-index

### DIFF
--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -55,7 +55,7 @@
   padding: 0;
   overflow: hidden;
   background-color: inherit;
-  z-index: 1;
+  z-index: 10;
   
   &:after {
     @include title;

--- a/src/styles/elements/c-navigation.scss
+++ b/src/styles/elements/c-navigation.scss
@@ -31,7 +31,7 @@
   font-weight: bold;
   text-transform: uppercase;
   background-color: #fff;
-  z-index: 1;
+  z-index: 10;
 }
 :host([slot=sub]) {
   background-color: #fff;
@@ -194,7 +194,7 @@ ul {
     .navbar-symbol {
       padding: 13px;
       background-color: inherit;
-      z-index: 1;
+      z-index: 10;
       display: block;
       position: absolute;
       top:0px;


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_
Increased the z-index for navigation because of the z-index: 1 for the buttons which is default in bootstrap 4 on active. 

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: scania/corporate-ui#540

**How to test**  
_Add description how to test if possible_
1. Create a page with button with active on it, e.g button primary active

**Screenshots**  
_If applicable, add screenshots to help explain_
Solved: 
![image](https://user-images.githubusercontent.com/35451568/80603295-80ab6180-8a30-11ea-986f-f3ed66d60564.png)


**Additional context**  
_Add any other context about the pull-request here._
Keep in mind, there might  be other elements that have it that we will implement in the future from bootstrap. 
