### PR TITLE
Improvement - c-table add styles for component with shadow root

### DIFF
--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -2,7 +2,7 @@
 
 .table {
   border: 1px solid $table-border-color;
-
+  border-collapse: collapse;
 
   caption {
     caption-side: top;

--- a/src/styles/elements/c-dropdown.scss
+++ b/src/styles/elements/c-dropdown.scss
@@ -2,3 +2,9 @@
 @import '../mixins';
 @import '../components/dropdowns';
 @import '../components/button';
+
+
+.dropdown-item.text-danger{
+  color: $danger;
+  color: Var(--danger);
+}

--- a/src/styles/elements/c-dropdown.scss
+++ b/src/styles/elements/c-dropdown.scss
@@ -1,0 +1,4 @@
+@import '../variables';
+@import '../mixins';
+@import '../components/dropdowns';
+@import '../components/button';

--- a/src/styles/elements/c-dropdown.scss
+++ b/src/styles/elements/c-dropdown.scss
@@ -1,10 +1,4 @@
 @import '../variables';
 @import '../mixins';
-@import '../components/dropdowns';
 @import '../components/button';
-
-
-.dropdown-item.text-danger{
-  color: $danger;
-  color: Var(--danger);
-}
+@import '../components/dropdowns';

--- a/src/styles/elements/c-table.scss
+++ b/src/styles/elements/c-table.scss
@@ -1,3 +1,9 @@
+@import '../variables';
+@import '../components/table';
+@import '../components/forms';
+@import '../components/dropdowns';
+@import '../components/button';
+
 .sort-desc {
   transform: rotate(180deg);
 }


### PR DESCRIPTION
**Describe pull-request**  
- Improve style for shadowRoot components to follow Scania styles
- Create stylesheet for dropdown component

**Solving issue**  
Fixes: https://github.com/scania/corporate-ui/issues/551

**How to test**  
Test together with https://github.com/scania/corporate-ui/pull/569


