### PR TITLE
Feature - 4px base font size

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -57,7 +57,8 @@ $dark-02:      #6c757d;
 $dark-03:      #212529;
 
 // Global Font variables
-$font-size-base:              1.4rem;
+//FIXME: Add correct rem
+$font-size-base:              3.5rem;
 $font-weight-normal:          400;
 $font-weight-base:            $font-weight-normal;
 $line-height-base:            1.5;

--- a/src/styles/components/_alert.scss
+++ b/src/styles/components/_alert.scss
@@ -1,6 +1,8 @@
 .alert {
   --link-color: none;
   --link-color-hover: none;
+  //FIXME: Add correct rem
+  padding: 1.875rem 3.125rem;
 
   a {
     color: inherit;

--- a/src/styles/components/_badges.scss
+++ b/src/styles/components/_badges.scss
@@ -1,6 +1,6 @@
 //TODO: Look into regular badges design
 //TODO: Fix focus colors on badge-link
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .badge {
   //FIXME: Add correct rem

--- a/src/styles/components/_badges.scss
+++ b/src/styles/components/_badges.scss
@@ -1,17 +1,20 @@
 //TODO: Look into regular badges design
 //TODO: Fix focus colors on badge-link
+@import '../core/grid/grid-vars';
 
 .badge {
-  padding: .5rem .85rem .5rem .85rem;
-  border-radius: 1.2rem;
-  font-size: 1.2rem;
-  line-height: 1.4rem;
+  //FIXME: Add correct rem
+  padding: 1.25rem 8.5px 1.25rem 8.5px;
+  border-radius: $spacing-element-04;
+  font-size: $spacing-element-04;
+  line-height: 3.5rem;
 
   &.badge-pill {
-    padding: .6rem 1.6rem .7rem 1.6rem;
-    border-radius: 1.6rem;
-    font-size: 1.4rem;
-    line-height: 1.7rem;
+    //FIXME: Add corect rem
+    padding: 1.5rem $spacing-element-05 1.75rem $spacing-element-05;
+    border-radius: $spacing-element-05;
+    font-size: 3.4rem;
+    line-height: 4.25rem;
   }
 
   @each $type in $types {

--- a/src/styles/components/_breadcrumbs.scss
+++ b/src/styles/components/_breadcrumbs.scss
@@ -1,5 +1,5 @@
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .breadcrumb {
   //FIXME: Add correct rem

--- a/src/styles/components/_breadcrumbs.scss
+++ b/src/styles/components/_breadcrumbs.scss
@@ -1,8 +1,10 @@
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 .breadcrumb {
-  font-size: 1.6rem;
-  padding: 1.2rem 1.6rem 1.3rem;
+  //FIXME: Add correct rem
+  font-size: $spacing-element-05;
+  padding: $spacing-element-04 $spacing-element-05 3.25rem;
   border-radius: $border-radius;
   background-color: $light-02; //TODO: Should breadcrumb be transparent
 

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -1,14 +1,17 @@
 @import '../variables';
 @import '../mixins';
+@import '../core/grid/grid-vars';
 
 .btn {
   --link-decoration: none;
   --link-decoration-hover: none;
 
-  border-radius: .3rem;
+  //FIXME: Add correct rem
+  border-radius: 0.75rem;
   border-radius: 3px;
-  padding: .9rem 1.8rem .8rem;
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  padding: 2.25rem 4.5rem $spacing-element-03;
+  font-size: 3.5rem;
   font-weight: bold;
 
   &,
@@ -71,12 +74,14 @@
     }
   }
   &-sm {
-    padding: .5rem 1.6rem .5rem;
-    font-size: 1.2rem;
+    //FIXME: Add correct rem
+    padding: 1.25rem $spacing-element-05 1.25rem;
+    font-size: $spacing-element-04;
   }
   &-lg {
-    padding: 1.4rem 2.0rem;
-    font-size: 1.6rem;
+    //FIXME: Add correct rem
+    padding: 3.5rem $spacing-element-06;
+    font-size: $spacing-element-05;
   }
 
   @at-root a#{&}.disabled {
@@ -149,7 +154,7 @@
           border-color: map-get($interaction-colors, $type);
           border-color: Var(--#{$type});
         }
-      }  
+      }
     }
   }
   @each $type in $interaction-types {

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -1,6 +1,6 @@
 @import '../variables';
 @import '../mixins';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .btn {
   --link-decoration: none;

--- a/src/styles/components/_cards.scss
+++ b/src/styles/components/_cards.scss
@@ -5,7 +5,8 @@
   border-radius: $border-radius;
 
   .card-body {
-    padding: 3.0rem 1.7rem;
+    //FIXME: Add correct rem
+    padding: 7rem 4.25rem;
   }
 
   //TODO: should it match regular a element

--- a/src/styles/components/_custom-forms.scss
+++ b/src/styles/components/_custom-forms.scss
@@ -5,7 +5,7 @@
 @import 'node_modules/bootstrap/scss/mixins/gradients';
 
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 $gray-500:                                        $dark-02;
 $component-bg:                                    theme-color("light");

--- a/src/styles/components/_custom-forms.scss
+++ b/src/styles/components/_custom-forms.scss
@@ -5,6 +5,7 @@
 @import 'node_modules/bootstrap/scss/mixins/gradients';
 
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 $gray-500:                                        $dark-02;
 $component-bg:                                    theme-color("light");
@@ -14,8 +15,9 @@ $component-active-bg:                             theme-color("primary");
 $custom-control-text-color:                       #53565A;
 $custom-control-disabled-color:                   #97999B;
 
-$custom-control-size:                             1.8rem;
-$custom-control-indicator-size:                   1.8rem;
+//FIXME: Add correct rem
+$custom-control-size:                             4.5rem;
+$custom-control-indicator-size:                   4.5rem;
 $custom-control-indicator-border-color:           transparent;
 $custom-control-indicator-border-width:           1px;
 
@@ -27,11 +29,12 @@ $custom-control-indicator-checked-border-color:   $custom-control-indicator-chec
 $custom-control-indicator-checked-disabled-bg:    lighten($component-active-bg, 20%);
 $custom-control-indicator-checked-box-shadow:     none;
 
-$custom-control-padding:                          ($custom-control-size + 1);
+//FIXME: Add correct rem
+$custom-control-padding:                          7rem;
 
-$custom-control-radio-space-around:               0.2;
-$custom-control-radio-size:                       ($custom-control-size - ($custom-control-radio-space-around * 2));
-$custom-control-radio-padding:                    ($custom-control-padding - $custom-control-radio-space-around);
+$custom-control-radio-space-around:               0.7rem;
+$custom-control-radio-size:                       3.5rem;
+$custom-control-radio-padding:                    6.5rem;
 
 $custom-switch-width:                             $custom-control-indicator-size * 1.9;
 $custom-switch-indicator-border-radius:           $custom-control-indicator-size / 2;
@@ -92,8 +95,8 @@ $custom-switch-indicator-size:                    calc(#{$custom-control-indicat
   .custom-control-input {
 
     &:checked ~ .custom-control-label::after {
-      width: 1.8rem;
-      left: -2.8rem;
+      width: 4.5rem;
+      left: -7rem;
     }
 
     &:disabled,
@@ -131,7 +134,7 @@ $custom-switch-indicator-size:                    calc(#{$custom-control-indicat
         background-color: Var(--primary);
         border-radius: 50%;
         left: ($custom-control-radio-padding * -1);
-        top: #{(2 * $custom-control-radio-space-around) + 0.05}rem;
+        top: $custom-control-radio-space-around;
       }
     }
 

--- a/src/styles/components/_dropdowns.scss
+++ b/src/styles/components/_dropdowns.scss
@@ -1,16 +1,20 @@
 @import '../variables';
 @import '../mixins';
+@import '../core/grid/grid-vars';
 
 .dropdown-menu{
-  padding: .8rem 1rem;
+  //FIXME: Add correct rem
+  padding: $spacing-element-03 2.5rem;
   border: 1px solid $light-04;
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
   border-radius: $border-radius;
 }
 
 .dropdown-item {
   color: $dark;
-  padding: .4rem .2rem;
+  //FIXME: Add correct rem
+  padding: $spacing-element-02 $spacing-element-01;
   text-decoration: none;
 
   &:focus,
@@ -28,17 +32,20 @@
 }
 
 .dropdown-toggle-split {
-  padding-right: 0.5625rem;
-  padding-left: 0.5625rem;
+  //FIXME: Add correct rem
+  padding-right: 5.625px;
+  padding-left: 5.625px;
 
  .btn-lg + & {
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    //FIXME: Add correct rem
+    padding-right: 1.875rem;
+    padding-left: 1.875rem;
  }
 
  .btn-sm + & {
-    padding-right: 0.375rem;
-    padding-left: 0.375rem;
+    //FIXME: Add correct rem
+    padding-right: 3.75px;
+    padding-left: 3.75px;
   }
 }
 

--- a/src/styles/components/_dropdowns.scss
+++ b/src/styles/components/_dropdowns.scss
@@ -1,6 +1,6 @@
 @import '../variables';
 @import '../mixins';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .dropdown-menu{
   //FIXME: Add correct rem

--- a/src/styles/components/_forms.scss
+++ b/src/styles/components/_forms.scss
@@ -1,5 +1,5 @@
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 // Input
 $input-border-color:          $border-color;

--- a/src/styles/components/_forms.scss
+++ b/src/styles/components/_forms.scss
@@ -1,11 +1,13 @@
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 // Input
 $input-border-color:          $border-color;
-$input-padding-x:             1.2rem;
-$input-padding-y:             1rem;
-$input-padding-y-sm:          0.7rem;
-$input-padding-x-sm:          1.2rem;
+//FIXME: Add correct rem
+$input-padding-x:             $spacing-element-04;
+$input-padding-y:             2.5rem;
+$input-padding-y-sm:          1.75rem;
+$input-padding-x-sm:          $spacing-element-04;
 $input-border-radius:         $border-radius;
 $input-background-color:      $secondary;
 
@@ -27,8 +29,9 @@ $form-validation-states: (
     color: Var(--dark);
   }
 
-  font-size: 1.4rem;
-  line-height: 1.6rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
+  line-height: $spacing-element-05;
   font-weight: 400;
   height: auto;
   border-radius: $input-border-radius;
@@ -64,7 +67,8 @@ $form-validation-states: (
     border-bottom: 1px solid Var(--light-04);
     padding-left: 0;
     border-radius: 0;
-    line-height: 2.1rem;
+    //FIXME: Add correct rem
+    line-height: 5.25rem;
     opacity: 0.8;
   }
 
@@ -78,13 +82,15 @@ $form-validation-states: (
 }
 
 .form-control-lg {
-  font-size: 2.1rem;
-  line-height: 2.8rem;
+   //FIXME: Add correct rem
+  font-size: 5.25rem;
+  line-height: 7rem;
 }
 
 .form-control-sm {
-  font-size: 1.2rem;
-  line-height: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: $spacing-element-04;
+  line-height: 3.5rem;
   padding: $input-padding-y-sm $input-padding-x-sm;
 }
 
@@ -95,8 +101,9 @@ select.form-control {
   appearance: none;
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMTIiIGhlaWdodD0iNjMiPjxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTEwNS4wOTcwMDAxNDA0Mjg1NSwyLjc2NTY1NTQ4MjQwNjI1OTZlLTggTDU2LjA4NDAwMDE0MDQyODU0LDQ5LjAxMjAwMDAyNzY1NjU3IEw3LjA3MTAwMDE0MDQyODUzOCwyLjc2NTY1NTQ4MjQwNjI1OTZlLTggbC03LjA3MSw3LjA3MSBMNTYuMDg0MDAwMTQwNDI4NTQsNjMuMTU1MDAwMDI3NjU2NTQgbDU2LjA4MywtNTYuMDg0IHoiLz48L3N2Zz4=);
   background-repeat: no-repeat;
-  background-size: 1.2rem;
-  background-position: calc(100% - 1.2rem) center;
+  //FIXME: Add correct rem
+  background-size: $spacing-element-04;
+  background-position: calc(100% - 3rem) center;
   padding-right: 40px;
 }
 
@@ -123,7 +130,8 @@ select.form-control[multiple] {
     line-height: normal;
     background-color: #fff;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.08);
-    padding: .8rem;
+    //FIXME: Add correct rem
+    padding: $spacing-element-03;
     border-radius: 5px;
   }
 
@@ -132,7 +140,8 @@ select.form-control[multiple] {
     &.is-#{$state},
     .was-validated &:#{$state} {
       background-image: none;
-      padding-right: 1.2rem;
+      //FIXME: Add correct rem
+      padding-right: $spacing-element-04;
 
       @each $key, $value in $data {
         #{$key} : map-get($theme-colors, $value);
@@ -155,5 +164,5 @@ select.form-control[multiple] {
 // Checkboxes and radios
 
 .form-check-label {
-  margin-left: 1rem;
+  margin-left: 2.5rem;
 }

--- a/src/styles/components/_list-group.scss
+++ b/src/styles/components/_list-group.scss
@@ -3,7 +3,8 @@
 .list-group {
 
   &-item {
-    padding: 1.7rem;
+    //FIXME: Add correct rem
+    padding: 4.25rem;
     border-color: $light-04;
     display: flex;
     text-decoration: none;

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -12,8 +12,10 @@
     padding: $modal-padding;
     border-color: $modal-border-color;
 
-    & .close { //TODO: Should look into the btn.close
-      font-size: 3rem;
+    & .close {
+      //TODO: Should look into the btn.close
+      //FIXME: Add correct rem
+      font-size: 7.5rem;
       font-weight: normal;
       padding: 5px;
     }

--- a/src/styles/components/_navs.scss
+++ b/src/styles/components/_navs.scss
@@ -4,9 +4,11 @@
   --link-color:#{$dark-01};
 
   text-decoration: none;
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
   font-weight: bold;
-  margin: 1rem 1.4rem 0.9rem;
+  //FIXME: Add correct rem
+  margin: 2.5rem 3.5rem 2.25rem;
   padding: 0;
 
   &:first-child {

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -1,7 +1,8 @@
 @import "../variables";
+@import "../core/spacing/spacing";
 
 .pagination {
-  font-size: 1.6rem;
+  font-size: $spacing-element-05;
 
   .page-item {
     background-color: $pagination-bg-color; //TODO: Look into background-color for every state
@@ -18,6 +19,8 @@
 
     //TODO: Focus state interaction with page-link
     .page-link {
+      //FIXME: Add correct rem
+      padding: 1.25rem 1.875rem;
       border: none;
       color: #909090;
       text-decoration: none;

--- a/src/styles/components/_progressbars.scss
+++ b/src/styles/components/_progressbars.scss
@@ -2,6 +2,7 @@
 // TODO: Add variable for border-radius that is global
 
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 .progress-bar {
   @include background('primary');
@@ -10,5 +11,6 @@
 .progress {
   border-radius: $border-radius;
   height: 12px; //Default height
-  font-size: 1.2rem;
+  //FIXME: Add correct rem
+  font-size: $spacing-element-04;
 }

--- a/src/styles/components/_progressbars.scss
+++ b/src/styles/components/_progressbars.scss
@@ -2,7 +2,7 @@
 // TODO: Add variable for border-radius that is global
 
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .progress-bar {
   @include background('primary');

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -6,7 +6,8 @@
 
   caption {
     caption-side: top;
-    padding: .75rem;
+    //FIXME: Add correct rem
+    padding: 1.875rem;
     font-weight: bold;
     color: $secondary;
     color: Var(--secondary);
@@ -31,12 +32,14 @@
   td {
     background-color: inherit;
     box-shadow: inherit;
+    //FIXME: add variable
     padding: 1.2rem 1.2rem 1.3rem;
   }
 
   &.table-sm {
     th,
     td {
+      //FIXME: add variable
       padding: .4rem .5rem .5rem;
     }
   }

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -1,5 +1,5 @@
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 .table {
   border: 1px solid $table-border-color;

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -1,4 +1,5 @@
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 .table {
   border: 1px solid $table-border-color;
@@ -32,15 +33,15 @@
   td {
     background-color: inherit;
     box-shadow: inherit;
-    //FIXME: add variable
-    padding: 1.2rem 1.2rem 1.3rem;
+    //FIXME: Add correct rem
+    padding: $spacing-element-04 $spacing-element-04 3.25rem;
   }
 
   &.table-sm {
     th,
     td {
-      //FIXME: add variable
-      padding: .4rem .5rem .5rem;
+      //FIXME: Add correct rem
+      padding: $spacing-element-01 1.25rem 1.25rem;
     }
   }
 }

--- a/src/styles/elements/c-content.scss
+++ b/src/styles/elements/c-content.scss
@@ -1,4 +1,4 @@
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 :host {
   display: flex;

--- a/src/styles/elements/c-content.scss
+++ b/src/styles/elements/c-content.scss
@@ -5,6 +5,7 @@
 }
 
 ::slotted(section) {
+  //FIXME: Add variable
   padding-top: 4rem;
   padding-bottom: 4rem;
 }

--- a/src/styles/elements/c-content.scss
+++ b/src/styles/elements/c-content.scss
@@ -1,3 +1,5 @@
+@import '../core/grid/grid-vars';
+
 :host {
   display: flex;
   flex-direction: column;
@@ -5,7 +7,7 @@
 }
 
 ::slotted(section) {
-  //FIXME: Add variable
-  padding-top: 4rem;
-  padding-bottom: 4rem;
+  //FIXME: Add correct rem
+  padding-top: $spacing-element-09;
+  padding-bottom: $spacing-element-09;
 }

--- a/src/styles/elements/c-cookie.scss
+++ b/src/styles/elements/c-cookie.scss
@@ -4,6 +4,7 @@
 @import '../components/list-group';
 @import '../components/custom-forms';
 @import '../utilities/typography';
+@import '../core/grid/grid-vars';
 
 @import 'node_modules/bootstrap/scss/mixins/breakpoints';
 @import 'node_modules/bootstrap/scss/utilities/spacing';
@@ -59,8 +60,8 @@ footer {
   .list-group {
 
     &-item {
-      //FIXME: Add variable
-      font-size: 1.6rem;
+      //FIXME: Add correct rem
+      font-size: $spacing-element-05;
       font-weight: bold;
       //FIXME: Add correct rem
       padding: 4.25rem 7.5rem;

--- a/src/styles/elements/c-cookie.scss
+++ b/src/styles/elements/c-cookie.scss
@@ -49,7 +49,8 @@ footer {
 @media (max-width: 991px) {
 
   ::slotted(a) {
-    padding: 1.7rem 3rem;
+    //FIXME: Add correct rem
+    padding: 4.25rem 7.5rem;
   }
 
   .main {
@@ -58,9 +59,11 @@ footer {
   .list-group {
 
     &-item {
+      //FIXME: Add variable
       font-size: 1.6rem;
       font-weight: bold;
-      padding: 1.7rem 3rem;
+      //FIXME: Add correct rem
+      padding: 4.25rem 7.5rem;
 
       &.active {
         background-color: transparent;

--- a/src/styles/elements/c-cookie.scss
+++ b/src/styles/elements/c-cookie.scss
@@ -4,7 +4,7 @@
 @import '../components/list-group';
 @import '../components/custom-forms';
 @import '../utilities/typography';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 @import 'node_modules/bootstrap/scss/mixins/breakpoints';
 @import 'node_modules/bootstrap/scss/utilities/spacing';

--- a/src/styles/elements/c-footer.scss
+++ b/src/styles/elements/c-footer.scss
@@ -23,7 +23,8 @@
 
   // These settings are needed to adjust the miss
   // alignment for brand icon files
-  font-size: 3.8rem;
+  //FIXME: Add correct rem
+  font-size: 9.5rem;
   padding: 2px;
 
   // IE
@@ -71,7 +72,8 @@
 
 // Copyright text
 p {
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
   color: #fff;
   text-align: center;
   padding: 50px 10px;
@@ -86,7 +88,8 @@ p {
   .navbar-nav {
     text-transform: uppercase;
     font-family: 'Scania Sans';
-    font-size: 1.4rem;
+    //FIXME: Add correct rem
+    font-size: 3.5rem;
     font-weight: bold;
     text-transform: uppercase;
     margin-top: 30px;
@@ -167,7 +170,8 @@ p {
     text-align: left;
     padding: 0;
     margin: 15px 0 0;
-    font-size: 1rem;
+    //FIXME: Add correct rem
+    font-size: 2.5rem;
     color: #97999b;
   }
 

--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -16,7 +16,8 @@
 @mixin title {
   font-family: 'Scania Sans Headline';
   font-weight: normal;
-  font-size: 1.8rem;
+  //FIXME: Add correct rem
+  font-size: 4.5rem;
   color: #53565a;
   line-height: 1;
   padding: 0 10px;
@@ -39,7 +40,8 @@
   flex-shrink: 0;
   background-color: #fff;
   font-family: 'Scania Sans';
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
   z-index: 1000;
   padding: 0;
   border-bottom: 1px solid #e2e2e2;
@@ -84,6 +86,7 @@
   }
   .navbar-nav {
     font-family: 'Scania Sans';
+    //FIXME: Add variable
     font-size: 1.2rem;
     text-transform: uppercase;
     color: #747472;

--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -1,4 +1,5 @@
 @import '../variables';
+@import '../core/grid/grid-vars';
 
 @mixin nav-link {
   color: $dark-02; // IE
@@ -86,8 +87,8 @@
   }
   .navbar-nav {
     font-family: 'Scania Sans';
-    //FIXME: Add variable
-    font-size: 1.2rem;
+    //FIXME: Add correct rem
+    font-size: $spacing-element-04;
     text-transform: uppercase;
     color: #747472;
     margin-top: -10px;

--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -161,6 +161,8 @@
   &-icon {
     // This make the icon the same size as the logotype, making it easier to handle the parent element padding needed
     margin: 8px;
+    //FIXME: Add correct rem
+    font-size: 3.125rem;
   }
 }
 

--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -1,5 +1,5 @@
 @import '../variables';
-@import '../core/grid/grid-vars';
+@import '../core/spacing/spacing';
 
 @mixin nav-link {
   color: $dark-02; // IE

--- a/src/styles/elements/c-modal.scss
+++ b/src/styles/elements/c-modal.scss
@@ -8,21 +8,25 @@
   &-header,
   &-body,
   &-footer {
-    padding-left: 3rem;
-    padding-right: 3rem;
+    //FIXME: Add correct rem
+    padding-left: 7.5rem;
+    padding-right: 7.5rem;
     border: 0;
   }
   &-header {
-    padding-top: 3rem;
+    //FIXME: Add correct rem
+    padding-top: 7.5rem;
     padding-bottom: 0;
   }
   &-body {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
+    //FIXME: Add correct rem
+    padding-top: 7.5rem;
+    padding-bottom: 7.5rem;
   }
   &-footer {
+    //FIXME: Add correct rem
     padding-top: 0;
-    padding-bottom: 3rem;
+    padding-bottom: 7.5rem;
   }
 }
 

--- a/src/styles/elements/c-navigation.scss
+++ b/src/styles/elements/c-navigation.scss
@@ -24,7 +24,8 @@
 
   display: block;
   font-family: 'Scania Sans';
-  font-size: 1.4rem;
+  //FIXME: Add correct rem
+  font-size: 3.5rem;
   font-weight: bold;
   text-transform: uppercase;
   background-color: #fff;

--- a/src/styles/utilities/loading.scss
+++ b/src/styles/utilities/loading.scss
@@ -36,7 +36,8 @@
 
     &:after {
       margin-top: -9px;
-      margin-left: -1rem;
+      //FIXME: Add correct rem
+      margin-left: -2.5rem;
     }
 
     &:not(:disabled):not(.disabled) {

--- a/src/styles/utilities/typography.scss
+++ b/src/styles/utilities/typography.scss
@@ -10,7 +10,8 @@ h6 {
   font-family: $headings-font-family;
   color: $headings-color;
   font-weight: bold;
-  margin-bottom: 1rem;
+  //FIXME: Add correct rem
+  margin-bottom: 2.5rem;
 }
 
 @include renderMap($heading-sizes, 'font-size');
@@ -47,11 +48,13 @@ a {
 }
 
 p {
-  margin-bottom: 1.5rem;
+  //FIXME: Add correct rem
+  margin-bottom: 3.75rem;
 }
 
 .lead {
-  font-size: 1.8rem;
+  //FIXME: Add correct rem
+  font-size: 4.5rem;
 }
 
 label {


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_
**Changes have been made in corporate-ui-site scania/corporate-ui-site#109 and corporate-ui scania/corporate-ui#595**
Adapt all the styling to follow 4px grid

- Font-size 4px in :root
- All components should look the same
- Alert have sizing from bootstrap, so no new changed have been added

Classes that use rem as a unit from bootstrap have been effected but not fixed, since it is specific bootstrap classes
- margin-top (mt), mb, mr and ml classes have not been set to the previous size
- Padding classes same as margin


**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #158 

**How to test**  
_Add description how to test if possible_
Should look the same as previous, only the unit have changed
- Run the corporate-ui-site and look at all the components

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
