### PR TITLE
Commenting out overflow: hidden as it hides dropdown content

### DIFF
--- a/src/styles/elements/c-header.scss
+++ b/src/styles/elements/c-header.scss
@@ -58,7 +58,7 @@
 .navbar {
   flex: 1;
   padding: 0;
-  overflow: hidden;
+  // overflow: hidden; This style is making so that the dropdown content is hidden behind <c-header>
   background-color: inherit;
   z-index: 10;
 


### PR DESCRIPTION
**Solving issue**  
I have noticed that the is hiding the content of the dropdowns placed in the header with the attribute (slot="items")

If I set the styling overflow: inherit for navbar inside , then it would appear. However i cant set it as it presides inside the shadow-root and i cant override its styling - overflow: hidden

Screenshots
C-UI 4
![image](https://user-images.githubusercontent.com/18164086/99055546-e52ba980-2599-11eb-850d-dcf7d5212883.png)

C-UI 3
![image](https://user-images.githubusercontent.com/18164086/99055662-eceb4e00-2599-11eb-8644-f37c9589e93d.png)